### PR TITLE
prevent calling former timers on resume

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -156,7 +156,8 @@ var timer = function(type, clear, fn, ms) {
       if (pauseIn) {
         setTimeout(this.pause, pauseIn);
       }
-
+      // Prevent to call wrapper
+      clear(id);
       // calling setTimeout here and not type because
       // calling setInterval with the remaining time will continue to
       // call setInterval with that lessened time


### PR DESCRIPTION
fixed the bug i have encountered on a project